### PR TITLE
feat(quadlet): MVP Pi-hole in rootless Quadlet

### DIFF
--- a/containers/pihole.container
+++ b/containers/pihole.container
@@ -4,7 +4,7 @@ Description=Pi-hole container
 [Container]
 AutoUpdate=registry
 ContainerName=pihole
-Environment=FTLCONF_dns_upstreams="1.1.1.1;8.8.8.8"
+Environment="FTLCONF_dns_upstreams=1.1.1.1;8.8.8.8"
 Environment=TZ=America/New_York
 Image=docker.io/pihole/pihole
 Network=pihole.network

--- a/containers/pihole.container
+++ b/containers/pihole.container
@@ -4,7 +4,7 @@ Description=Pi-hole container
 [Container]
 AutoUpdate=registry
 ContainerName=pihole
-Environment="FTLCONF_dns_upstreams=1.1.1.1;8.8.8.8"
+Environment=FTLCONF_dns_upstreams=1.1.1.1
 Environment=TZ=America/New_York
 Image=docker.io/pihole/pihole
 Network=pihole.network

--- a/containers/pihole.container
+++ b/containers/pihole.container
@@ -11,7 +11,7 @@ PublishPort=53:53/tcp
 PublishPort=53:53/udp
 PublishPort=80:80/tcp
 PublishPort=443:443/tcp
-Volume=%h/etc-pihole:/etc/pihole
+Volume=pihole.volume:/pihole
 
 [Service]
 Restart=always

--- a/containers/pihole.container
+++ b/containers/pihole.container
@@ -1,0 +1,21 @@
+[Unit]
+Description=Pi-hole container
+
+[Container]
+AutoUpdate=registry
+ContainerName=pihole
+Environment=TZ=America/New_York
+Image=pihole/pihole:latest
+Network=pihole.network
+PublishPort=53:53/tcp
+PublishPort=53:53/udp
+PublishPort=80:80/tcp
+PublishPort=443:443/tcp
+Volume=%h/etc-pihole:/etc/pihole
+
+[Service]
+Restart=always
+
+[Install]
+# Start automtically by default on boot
+WantedBy=default.target

--- a/containers/pihole.container
+++ b/containers/pihole.container
@@ -5,7 +5,7 @@ Description=Pi-hole container
 AutoUpdate=registry
 ContainerName=pihole
 Environment=TZ=America/New_York
-Image=pihole/pihole:latest
+Image=docker.io/pihole/pihole
 Network=pihole.network
 PublishPort=53:53/tcp
 PublishPort=53:53/udp

--- a/containers/pihole.container
+++ b/containers/pihole.container
@@ -4,7 +4,7 @@ Description=Pi-hole container
 [Container]
 AutoUpdate=registry
 ContainerName=pihole
-Environment=FTLCONF_dns_upstreams=1.1.1.1;8.8.8.8
+Environment=FTLCONF_dns_upstreams="1.1.1.1;8.8.8.8"
 Environment=TZ=America/New_York
 Image=docker.io/pihole/pihole
 Network=pihole.network

--- a/containers/pihole.container
+++ b/containers/pihole.container
@@ -4,6 +4,7 @@ Description=Pi-hole container
 [Container]
 AutoUpdate=registry
 ContainerName=pihole
+Environment=FTLCONF_dns_upstreams=1.1.1.1;8.8.8.8
 Environment=TZ=America/New_York
 Image=docker.io/pihole/pihole
 Network=pihole.network

--- a/containers/pihole.network
+++ b/containers/pihole.network
@@ -1,0 +1,1 @@
+[Network]

--- a/containers/pihole.volume
+++ b/containers/pihole.volume
@@ -1,0 +1,2 @@
+[Volume]
+Driver=local

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -eou pipefail
+
+# Enable linger so the rootless user services can be started without the user being logged in
+loginctl enable-linger
+
+# Copy container files to ~/.config/containers/systemd
+# See also https://docs.podman.io/en/latest/markdown/podman-systemd.unit.5.html#podman-rootless-unit-search-path
+mkdir -p ~/.config/containers/systemd/pihole
+cp -a containers/. ~/.config/containers/systemd/pihole/
+
+# Reload unit files and rebuild dependency trees 
+systemctl --user daemon-reload
+
+# Start the service now
+systemctl --user start pihole

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -eou pipefail
+
+# Stop the service now
+systemctl --user stop pihole
+
+# Remove the container files from ~/.config/containers/systemd
+rm -rf ~/.config/containers/systemd/pihole/
+
+# Reload unit files and rebuild dependency trees 
+systemctl --user daemon-reload


### PR DESCRIPTION
> [!WARNING]
> Seeing a lot of issues creating and starting the container, taking upwards of 15 minutes. As this is a DNS sinkhole and is being run on a server responsible for exposing other services that rely on a network connection, this negatively affects those services and essentially blocks them from being used until Pi-hole can serve traffic.